### PR TITLE
Fix issue w/ A values used after LDA #$00 / sta $address -> STZ $address optimization. 

### DIFF
--- a/opt6502.c
+++ b/opt6502.c
@@ -1379,16 +1379,16 @@ void optimize_65c02_instructions_ast(Program *prog) {
             continue;
         }
 
-        // Pattern: LDA #$00 followed by one or more STA -> convert all STA to STZ and mark LDA dead
+        // Pattern: LDA #$00 followed by one or more STA -> convert all STA to STZ
+        // If A is not used after the STAs, also mark LDA #$00 as dead
         if (node->opcode && strcmp(node->opcode, "LDA") == 0 &&
             node->operand && (strcmp(node->operand, "#$00") == 0 || strcmp(node->operand, "#0") == 0)) {
 
-            // Look ahead to see if we can convert STAs to STZ
+            // First pass: scan forward to check if A is used and find STAs
             AstNode *current = node->next;
             bool found_sta = false;
-            bool can_optimize = true;
+            bool a_value_used = false;  // Track if accumulator value is used (not just modified)
 
-            // First pass: check if optimization is possible
             while (current && !current->is_branch_target) {
                 if (current->is_dead || current->no_optimize) {
                     current = current->next;
@@ -1405,18 +1405,19 @@ void optimize_65c02_instructions_ast(Program *prog) {
                     strcmp(current->opcode, "ORA") == 0 ||
                     strcmp(current->opcode, "EOR") == 0 ||
                     strcmp(current->opcode, "CMP") == 0 ||
+                    strcmp(current->opcode, "BIT") == 0 ||
                     strcmp(current->opcode, "PHA") == 0 ||
                     strcmp(current->opcode, "TAX") == 0 ||
                     strcmp(current->opcode, "TAY") == 0)) {
-                    // Instruction uses A but doesn't modify it (or PHA/TAX/TAY which preserve A for STZ)
-                    can_optimize = false;
+                    // Instruction uses A value - can't remove LDA but can still convert STA to STZ
+                    a_value_used = true;
                     break;
                 } else if (current->opcode && (
                     strcmp(current->opcode, "LDA") == 0 ||
                     strcmp(current->opcode, "PLA") == 0 ||
                     strcmp(current->opcode, "TXA") == 0 ||
                     strcmp(current->opcode, "TYA") == 0)) {
-                    // A is reloaded/modified
+                    // A is reloaded/modified - safe to remove original LDA
                     break;
                 } else {
                     // Other instructions that don't use A - safe to continue
@@ -1424,8 +1425,8 @@ void optimize_65c02_instructions_ast(Program *prog) {
                 }
             }
 
-            // Second pass: apply optimization if we found STAs and it's safe
-            if (found_sta && can_optimize) {
+            // Second pass: convert STAs to STZ if we found any
+            if (found_sta) {
                 current = node->next;
                 while (current && !current->is_branch_target) {
                     if (current->is_dead || current->no_optimize) {
@@ -1445,18 +1446,34 @@ void optimize_65c02_instructions_ast(Program *prog) {
                         strcmp(current->opcode, "LDA") == 0 ||
                         strcmp(current->opcode, "PLA") == 0 ||
                         strcmp(current->opcode, "TXA") == 0 ||
-                        strcmp(current->opcode, "TYA") == 0)) {
-                        // A is modified
+                        strcmp(current->opcode, "TYA") == 0 ||
+                        strcmp(current->opcode, "ADC") == 0 ||
+                        strcmp(current->opcode, "SBC") == 0 ||
+                        strcmp(current->opcode, "AND") == 0 ||
+                        strcmp(current->opcode, "ORA") == 0 ||
+                        strcmp(current->opcode, "EOR") == 0 ||
+                        strcmp(current->opcode, "CMP") == 0 ||
+                        strcmp(current->opcode, "BIT") == 0 ||
+                        strcmp(current->opcode, "PHA") == 0 ||
+                        strcmp(current->opcode, "TAX") == 0 ||
+                        strcmp(current->opcode, "TAY") == 0)) {
+                        // A is modified or used - stop scanning
                         break;
                     } else {
                         current = current->next;
                     }
                 }
 
-                // Mark the LDA #$00 as dead since we're using STZ instead
-                node->is_dead = true;
-                if (prog->trace_level > 1) {
-                    printf("DEBUG 65c02: Marked LDA #0 at line %d as dead, converted STAs to STZ\n", node->line_num);
+                // Only mark LDA #$00 as dead if A value is not used later
+                if (!a_value_used) {
+                    node->is_dead = true;
+                    if (prog->trace_level > 1) {
+                        printf("DEBUG 65c02: Marked LDA #0 at line %d as dead, converted STAs to STZ\n", node->line_num);
+                    }
+                } else {
+                    if (prog->trace_level > 1) {
+                        printf("DEBUG 65c02: Kept LDA #0 at line %d (A used later), but converted STAs to STZ\n", node->line_num);
+                    }
                 }
             }
         }

--- a/plan.txt
+++ b/plan.txt
@@ -2,43 +2,85 @@
 
 This file outlines potential areas for improvement and future changes to the `opt6502` project.
 
+## Recently Completed (2026-01):
+✅ **AST Implementation** - Complete Abstract Syntax Tree for program representation
+✅ **Register & Flag Tracking** - Comprehensive validation system for A/X/Y/Z registers and C/N/Z/V flags
+✅ **Comment Preservation** - Inline comments maintained through optimization
+✅ **Enhanced 65C02 Optimizations** - Improved STZ generation with redundant LDA removal
+✅ **Enhanced 45GS02 Optimizations** - Fixed Z register optimization, handles multiple stores
+✅ **Test Suite** - Comprehensive regression tests with validation test directory
+✅ **Test Infrastructure** - Automated testing with CPU-specific flag detection
+
 ## High-Level Goals:
-- Improve code readability and maintainability.
-- Enhance optimization passes for better code generation.
-- Expand test coverage to ensure correctness and prevent regressions.
-- Support additional CPU architectures or instruction sets.
+- Leverage register/flag tracking for advanced optimizations
+- Further improve optimization passes for better code generation
+- Expand test coverage to ensure correctness and prevent regressions
+- Enhance documentation with new features
 
 ## Specific Areas:
 
-### 1. Codebase Refactoring & Readability:
-- Review and refactor `opt6502.c` for clearer function separation and modularity.
-- Add comments to complex logic sections.
-- Ensure consistent coding style across the project.
-
-### 2. Optimization Enhancements:
+### 1. Optimization Enhancements (Using Register/Flag Tracking):
+- **Dead Flag Write Elimination:**
+    - Detect and remove flag-setting operations when flags are not read before being set again
+    - Example: Remove redundant CLC before ADC when carry is already clear
+- **Redundant Compare Elimination:**
+    - Use register value tracking to eliminate unnecessary comparisons
+    - Remove CMP when register value is known and result is predictable
+- **Flag-Based Constant Propagation:**
+    - Track flag states across basic blocks for better constant propagation
+    - Optimize branches based on known flag states
+- **Zero Detection Optimization:**
+    - When register is known to be zero, optimize stores and comparisons
+    - Convert more patterns to STZ on 65C02/45GS02
+- **Carry Flag Optimization:**
+    - Track carry flag state to eliminate redundant CLC/SEC instructions
+- **Branch Prediction:**
+    - Use flag knowledge to predict branch outcomes
+    - Enable more aggressive dead code elimination after predictable branches
 - **Peephole Optimizations:**
-    - Identify and implement more peephole optimization patterns.
-    - Improve existing peephole passes (e.g., redundant loads/stores, branch optimizations).
+    - Add more patterns leveraging register/flag knowledge
+    - Identify complex instruction sequences that can be simplified
+
+### 2. Additional Optimization Passes:
 - **Dead Code Elimination:**
-    - Enhance detection of unreachable code blocks.
-    - Implement more aggressive dead code removal.
+    - Use register tracking to identify unused computations
+    - Remove code that sets registers that are never read
 - **Register Allocation:**
-    - Consider implementing a simple register allocator for improved code efficiency.
-- **Instruction Simplification:**
-    - Look for opportunities to replace complex instruction sequences with simpler, more efficient ones.
+    - Use register usage analysis for better allocation decisions
+    - Identify opportunities to reuse register values
+- **Instruction Scheduling:**
+    - Reorder independent instructions for better pipelining
+    - Consider CPU-specific instruction timing
 
 ### 3. Testing Improvements:
-- Add unit tests for individual optimization functions.
-- Expand integration tests to cover more complex code scenarios and edge cases.
-- Automate test execution and reporting.
+- Add unit tests for register/flag tracking functions
+- Create tests specifically for new optimization opportunities
+- Add performance benchmarking suite
+- Test edge cases in flag tracking (overflow, carry combinations)
 
 ### 4. Documentation:
-- Improve `README.md` with more detailed explanations of the optimizer's functionality, usage, and supported features.
-- Document internal architecture and design decisions.
+- Update `README.md` with register/flag tracking features
+- Document optimization opportunities enabled by tracking system
+- Add examples showing before/after optimization with explanation
+- Document internal architecture including AST and validation system
+- Create developer guide for adding new optimizations
 
-### 5. Build System:
-- Review `Makefile` for potential improvements in build process, dependencies, and portability.
+### 5. Code Quality:
+- Add more detailed comments to complex optimization logic
+- Consider splitting large optimization functions into smaller helpers
+- Profile and optimize hot paths in the optimizer itself
 
-### 6. New Features:
-- Support for other 65xx family CPUs (e.g., 65c816).
-- Implement an AST or IR for more sophisticated optimizations.
+### 6. Future Features:
+- **Enhanced 65816 Support:**
+    - Full 16-bit mode support
+    - Track 16-bit register states
+    - Optimize 16-bit operations
+- **Profile-Guided Optimization:**
+    - Accept profiling data to guide optimization decisions
+    - Optimize hot code paths differently from cold paths
+- **Link-Time Optimization:**
+    - Cross-function optimization using register/flag tracking
+    - Inline small subroutines with known behavior
+- **Optimization Statistics:**
+    - Detailed reporting of which optimizations were applied and where
+    - Performance estimation (cycle counting)


### PR DESCRIPTION
  - Safe case: When A value is NOT used after STA, both the LDA #$00 is removed and STA is converted to STZ
    - LDA #$00 / STA $1000 / STA $1001 → STZ $1000 / STZ $1001
  - Critical case: When A value IS used later (like in ADC), LDA #$00 is preserved and STA is still converted to STZ
    - LDA #$00 / STA $1000 / CLC / ADC $1001 / STA $1002 → LDA #$00 / STZ $1000 / CLC / ADC $1001 / STA $1002

  The optimizer now correctly distinguishes between:
  - Instructions that USE A value (can't remove LDA): ADC, SBC, AND, ORA, EOR, CMP, BIT, PHA, TAX, TAY
  - Instructions that MODIFY A (safe to remove LDA): LDA, PLA, TXA, TYA